### PR TITLE
Fix elastic beanstalk deploy configuration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,7 +14,6 @@
   "django_storages":        ["enabled", "disabled"],
   "docker":                 ["enabled", "disabled"],
   "elastic_beanstalk":      ["enabled", "disabled"],
-  "sentry":                 ["enabled", "disabled"],
   "pre_commit":             ["enabled", "disabled"],
   "sass_bootstrap":         ["enabled", "disabled"],
   "security_settings":      ["enabled", "disabled"],

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -8,6 +8,10 @@ CONDITIONAL_REMOVE_PATHS = [
     "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.ebextensions{% endif %}",
     "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.elasticbeanstalk{% endif %}",
     "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.platform{% endif %}",
+    "{% if cookiecutter.docker == 'disabled' %}Dockerfile{% endif %}",
+    "{% if cookiecutter.pre_commit == 'disabled' %}.pre-commit-config.yaml{% endif %}",
+    "{% if cookiecutter.django_react == 'disabled' %}config/webpack_loader.py{% endif %}",
+    "{% if cookiecutter.django_react == 'disabled' %}nwb.config.js{% endif %}",
 ]
 
 
@@ -20,7 +24,10 @@ def main():
 def delete_conditional_paths():
     for path in CONDITIONAL_REMOVE_PATHS:
         if path and os.path.exists(path):
-            shutil.rmtree(path)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
 
 
 def delete_empty_files():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,6 +9,7 @@ CONDITIONAL_REMOVE_PATHS = [
     "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.elasticbeanstalk{% endif %}",
     "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.platform{% endif %}",
     "{% if cookiecutter.docker == 'disabled' %}Dockerfile{% endif %}",
+    "{% if cookiecutter.docker == 'disabled' %}.dockerignore{% endif %}",
     "{% if cookiecutter.pre_commit == 'disabled' %}.pre-commit-config.yaml{% endif %}",
     "{% if cookiecutter.django_react == 'disabled' %}config/webpack_loader.py{% endif %}",
     "{% if cookiecutter.django_react == 'disabled' %}nwb.config.js{% endif %}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,11 +1,26 @@
 import glob
 import os
+import shutil
 from os import path
 
 
+CONDITIONAL_REMOVE_PATHS = [
+    "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.ebextensions{% endif %}",
+    "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.elasticbeanstalk{% endif %}",
+    "{% if cookiecutter.elastic_beanstalk == 'disabled' %}.platform{% endif %}",
+]
+
+
 def main():
+    delete_conditional_paths()
     delete_empty_files()
     print_next_steps()
+
+
+def delete_conditional_paths():
+    for path in CONDITIONAL_REMOVE_PATHS:
+        if path and os.path.exists(path):
+            shutil.rmtree(path)
 
 
 def delete_empty_files():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -13,6 +13,7 @@ CONDITIONAL_REMOVE_PATHS = [
     "{% if cookiecutter.pre_commit == 'disabled' %}.pre-commit-config.yaml{% endif %}",
     "{% if cookiecutter.django_react == 'disabled' %}config/webpack_loader.py{% endif %}",
     "{% if cookiecutter.django_react == 'disabled' %}nwb.config.js{% endif %}",
+    "{% if cookiecutter.django_react == 'disabled' and cookiecutter.sass_bootstrap == 'disabled' %}package.json{% endif %}",
 ]
 
 

--- a/{{cookiecutter.project_slug}}/.ebextensions/django.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/django.config
@@ -9,10 +9,14 @@ commands:
     command: sudo amazon-linux-extras enable postgresql10
   02_postgres_install:
     command: sudo yum install -y postgresql-devel
+  {% if cookiecutter.django_react == "enabled" or cookiecutter.sass_bootstrap == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react, sass_bootstrap{%- endif %}
   03_install_node:
     cwd: /tmp
     test: '[ ! -f /usr/bin/node ] && echo "Node not installed; installing Node"'
-    command: 'curl -sL https://rpm.nodesource.com/setup_16.x | sudo bash - && yum install -y nodejs'
+    command: 'curl -sL https://rpm.nodesource.com/setup_12.x | sudo bash - && yum install -y nodejs'
+  {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react, sass_bootstrap{%- endif %}
+  {%- endif %}
 
 container_commands:
   01_update_pip:
@@ -28,31 +32,6 @@ container_commands:
       source $PYTHONPATH/activate
       python manage.py migrate --noinput
     leader_only: true
-  04_install_js_requirements:
-    command: |
-      npm install
-
-  {% if cookiecutter.django_react == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
-  05_build_react_components:
-    command: |
-      $(npm bin)/nwb build --no-vendor
-  {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
-  {%- endif -%}
-
-  {% if cookiecutter.sass_bootstrap == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
-  06_compile_scss:
-    command: |
-      source $PYTHONPATH/activate
-      python manage.py compilescss
-  {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
-  {%- endif -%}
-
-  07_collectstatic:
-    command: |
-      source $PYTHONPATH/activate
-      python manage.py collectstatic --noinput
 
 option_settings:
   aws:elasticbeanstalk:environment:proxy:

--- a/{{cookiecutter.project_slug}}/.ebextensions/django.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/django.config
@@ -1,6 +1,4 @@
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 packages:
   yum:
     amazon-linux-extras: []
@@ -14,7 +12,7 @@ commands:
   03_install_node:
     cwd: /tmp
     test: '[ ! -f /usr/bin/node ] && echo "Node not installed; installing Node"'
-    command: 'curl -sL https://rpm.nodesource.com/setup_12.x | sudo bash - && yum install -y nodejs'
+    command: 'curl -sL https://rpm.nodesource.com/setup_16.x | sudo bash - && yum install -y nodejs'
 
 container_commands:
   01_update_pip:
@@ -33,30 +31,28 @@ container_commands:
   04_install_js_requirements:
     command: |
       npm install
-  {%- if cookiecutter.elastic_beanstalk == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-  # START_FEATURE django_react
+
+  {% if cookiecutter.django_react == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
   05_build_react_components:
     command: |
       $(npm bin)/nwb build --no-vendor
-  # END_FEATURE django_react
-  {%- endif %}
-  {%- endif %}
-  {%- if cookiecutter.sass_bootstrap == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-  # START_FEATURE sass_bootstrap
+  {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
+  {%- endif -%}
+
+  {% if cookiecutter.sass_bootstrap == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
   06_compile_scss:
     command: |
       source $PYTHONPATH/activate
       python manage.py compilescss
-  # END_FEATURE sass_bootstrap
-  {%- endif %}
-  {%- endif %}
+  {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
+  {%- endif -%}
+
   07_collectstatic:
     command: |
       source $PYTHONPATH/activate
       python manage.py collectstatic --noinput
-
 
 option_settings:
   aws:elasticbeanstalk:environment:proxy:
@@ -95,6 +91,4 @@ files:
       "\e[A":history-search-backward
       ## arrow down
       "\e[B":history-search-forward
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.ebextensions/django.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/django.config
@@ -1,4 +1,3 @@
-{%- if cookiecutter.elastic_beanstalk == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE elastic_beanstalk
 {%- endif %}
@@ -12,7 +11,10 @@ commands:
     command: sudo amazon-linux-extras enable postgresql10
   02_postgres_install:
     command: sudo yum install -y postgresql-devel
-
+  03_install_node:
+    cwd: /tmp
+    test: '[ ! -f /usr/bin/node ] && echo "Node not installed; installing Node"'
+    command: 'curl -sL https://rpm.nodesource.com/setup_12.x | sudo bash - && yum install -y nodejs'
 
 container_commands:
   01_update_pip:
@@ -28,6 +30,33 @@ container_commands:
       source $PYTHONPATH/activate
       python manage.py migrate --noinput
     leader_only: true
+  04_install_js_requirements:
+    command: |
+      npm install
+  {%- if cookiecutter.elastic_beanstalk == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
+  # START_FEATURE django_react
+  05_build_react_components:
+    command: |
+      $(npm bin)/nwb build --no-vendor
+  # END_FEATURE django_react
+  {%- endif %}
+  {%- endif %}
+  {%- if cookiecutter.sass_bootstrap == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
+  # START_FEATURE sass_bootstrap
+  06_compile_scss:
+    command: |
+      source $PYTHONPATH/activate
+      python manage.py compilescss
+  # END_FEATURE sass_bootstrap
+  {%- endif %}
+  {%- endif %}
+  07_collectstatic:
+    command: |
+      source $PYTHONPATH/activate
+      python manage.py collectstatic --noinput
+
 
 option_settings:
   aws:elasticbeanstalk:environment:proxy:
@@ -68,5 +97,4 @@ files:
       "\e[B":history-search-forward
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE elastic_beanstalk
-{%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.elasticbeanstalk/eb_create_environment.yml
+++ b/{{cookiecutter.project_slug}}/.elasticbeanstalk/eb_create_environment.yml
@@ -1,4 +1,3 @@
-{%- if cookiecutter.elastic_beanstalk == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE elastic_beanstalk
 {%- endif %}
@@ -48,5 +47,4 @@ RDS:
     LicenseModel: "postgresql-license"
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE elastic_beanstalk
-{%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.elasticbeanstalk/eb_create_environment.yml
+++ b/{{cookiecutter.project_slug}}/.elasticbeanstalk/eb_create_environment.yml
@@ -1,6 +1,4 @@
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 # https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
 ElasticBeanstalk:
   # aws elasticbeanstalk list-available-solution-stacks --region us-east-1
@@ -45,6 +43,4 @@ RDS:
     Port: 5432
     DBParameterGroupName: "default.postgres12"
     LicenseModel: "postgresql-license"
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
@@ -1,33 +1,31 @@
-{%- if cookiecutter.elastic_beanstalk == "enabled" -%}
+#!/bin/bash
 {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE elastic_beanstalk
 {%- endif %}
-#!/bin/bash
 source $PYTHONPATH/activate
 
-{% if cookiecutter.django_react == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
+{%- if cookiecutter.django_react == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE django_react
-{%- endif %}
+  {%- endif %}
 npm install
-./node_modules/.bin/nwb build --no-vendor
-{%- if cookiecutter.feature_annotations == "on" %}
+$(npm bin)/nwb build --no-vendor
+  {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE django_react
-
-{% endif -%}
+  {% endif -%}
 {%- endif -%}
+
 {%- if cookiecutter.sass_bootstrap == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE sass_bootstrap
-{%- endif %}
+  {%- endif %}
 python manage.py compilescss
-{%- if cookiecutter.feature_annotations == "on" %}
+  {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE sass_bootstrap
-
-{% endif -%}
+  {% endif -%}
 {%- endif -%}
+
 python manage.py collectstatic --noinput --ignore *.scss
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE elastic_beanstalk
-{%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 {% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 source $PYTHONPATH/activate
-npm install
+
+{% if cookiecutter.django_react == "enabled" or cookiecutter.sass_bootstrap == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react, sass_bootstrap{%- endif %}
+npm install --production
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react, sass_bootstrap{%- endif %}
+{%- endif %}
 
 {% if cookiecutter.django_react == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
 $(npm bin)/nwb build --no-vendor
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
-
-{% endif -%}
+{%- endif %}
 
 {% if cookiecutter.sass_bootstrap == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
 python manage.py compilescss
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
-
-{% endif -%}
+{%- endif %}
 
 python manage.py collectstatic --noinput --ignore *.scss
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/confighooks/predeploy/predeploy.sh
@@ -1,31 +1,21 @@
 #!/bin/bash
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 source $PYTHONPATH/activate
-
-{%- if cookiecutter.django_react == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE django_react
-  {%- endif %}
 npm install
-$(npm bin)/nwb build --no-vendor
-  {%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE django_react
-  {% endif -%}
-{%- endif -%}
 
-{%- if cookiecutter.sass_bootstrap == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE sass_bootstrap
-  {%- endif %}
+{% if cookiecutter.django_react == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
+$(npm bin)/nwb build --no-vendor
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
+
+{% endif -%}
+
+{% if cookiecutter.sass_bootstrap == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
 python manage.py compilescss
-  {%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE sass_bootstrap
-  {% endif -%}
-{%- endif -%}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
+
+{% endif -%}
 
 python manage.py collectstatic --noinput --ignore *.scss
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
@@ -1,33 +1,31 @@
-{%- if cookiecutter.elastic_beanstalk == "enabled" -%}
+#!/bin/bash
 {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE elastic_beanstalk
 {%- endif %}
-#!/bin/bash
 source $PYTHONPATH/activate
 
-{% if cookiecutter.django_react == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
+{%- if cookiecutter.django_react == "enabled" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE django_react
-{%- endif %}
+  {%- endif %}
 npm install
-./node_modules/.bin/nwb build --no-vendor
-{%- if cookiecutter.feature_annotations == "on" %}
+$(npm bin)/nwb build --no-vendor
+  {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE django_react
-
-{% endif -%}
+  {% endif -%}
 {%- endif -%}
+
 {%- if cookiecutter.sass_bootstrap == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
+  {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE sass_bootstrap
-{%- endif %}
+  {%- endif %}
 python manage.py compilescss
-{%- if cookiecutter.feature_annotations == "on" %}
+  {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE sass_bootstrap
-
-{% endif -%}
+  {% endif -%}
 {%- endif -%}
+
 python manage.py collectstatic --noinput --ignore *.scss
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE elastic_beanstalk
-{%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 {% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 source $PYTHONPATH/activate
-npm install
+
+{% if cookiecutter.django_react == "enabled" or cookiecutter.sass_bootstrap == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react, sass_bootstrap{%- endif %}
+npm install --production
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react, sass_bootstrap{%- endif %}
+{%- endif %}
 
 {% if cookiecutter.django_react == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
 $(npm bin)/nwb build --no-vendor
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
-
-{% endif -%}
+{%- endif %}
 
 {% if cookiecutter.sass_bootstrap == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
 python manage.py compilescss
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
-
-{% endif -%}
+{%- endif %}
 
 python manage.py collectstatic --noinput --ignore *.scss
 {% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
+++ b/{{cookiecutter.project_slug}}/.platform/hooks/predeploy/predeploy.sh
@@ -1,31 +1,21 @@
 #!/bin/bash
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 source $PYTHONPATH/activate
-
-{%- if cookiecutter.django_react == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE django_react
-  {%- endif %}
 npm install
-$(npm bin)/nwb build --no-vendor
-  {%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE django_react
-  {% endif -%}
-{%- endif -%}
 
-{%- if cookiecutter.sass_bootstrap == "enabled" -%}
-  {%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE sass_bootstrap
-  {%- endif %}
+{% if cookiecutter.django_react == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
+$(npm bin)/nwb build --no-vendor
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
+
+{% endif -%}
+
+{% if cookiecutter.sass_bootstrap == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
 python manage.py compilescss
-  {%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE sass_bootstrap
-  {% endif -%}
-{%- endif -%}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
+
+{% endif -%}
 
 python manage.py collectstatic --noinput --ignore *.scss
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/httpd/conf.d/ssl_rewrite.conf
+++ b/{{cookiecutter.project_slug}}/.platform/httpd/conf.d/ssl_rewrite.conf
@@ -1,10 +1,6 @@
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE elastic_beanstalk{%- endif %}
 RewriteEngine On
 <If "-n '%{HTTP:X-Forwarded-Proto}' && %{HTTP:X-Forwarded-Proto} != 'https'">
 RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 </If>
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE elastic_beanstalk
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE elastic_beanstalk{%- endif %}

--- a/{{cookiecutter.project_slug}}/.platform/httpd/conf.d/ssl_rewrite.conf
+++ b/{{cookiecutter.project_slug}}/.platform/httpd/conf.d/ssl_rewrite.conf
@@ -1,4 +1,3 @@
-{%- if cookiecutter.elastic_beanstalk == "enabled" -%}
 {%- if cookiecutter.feature_annotations == "on" -%}
 # START_FEATURE elastic_beanstalk
 {%- endif %}
@@ -8,5 +7,4 @@ RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 </If>
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE elastic_beanstalk
-{%- endif %}
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,7 +1,4 @@
-{%- if cookiecutter.pre_commit == "enabled" %}
-{%- if cookiecutter.feature_annotations == "on" %}
-# START_FEATURE pre_commit
-{%- endif %}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE pre_commit{%- endif %}
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
@@ -16,18 +13,15 @@ repos:
   - id: check-yaml
   - id: check-merge-conflict
   - id: check-added-large-files
--   repo: https://gitlab.com/PyCQA/flake8
+- repo: https://gitlab.com/PyCQA/flake8
     rev: 3.9.0
     hooks:
     -   id: flake8
         types: [file, python]
         args: ['--config=config/setup.cfg']
--   repo: https://github.com/pycqa/isort
+- repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:
     -   id: isort
         types: [file, python]
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE pre_commit
-{%- endif %}
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE pre_commit{%- endif %}

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,7 +1,4 @@
-{%- if cookiecutter.docker == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE docker
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE docker{%- endif %}
 FROM python:3.8.8-slim-buster
 
 WORKDIR /app
@@ -26,42 +23,34 @@ ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 
 {% if cookiecutter.django_react == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE django_react
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
 COPY ./nwb.config.js /app/nwb.config.js
 COPY ./package.json /app/package.json
 COPY ./package-lock.json /app/package-lock.json
-
 RUN npm install
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE django_react
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
 
 {% endif -%}
-{%- endif -%}
+
+
 COPY . /app/
 COPY ./config/.env.example /app/config/.env
 
 {% if cookiecutter.django_react == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE django_react
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" -%}# START_FEATURE django_react{%- endif %}
 RUN ./node_modules/.bin/nwb build --no-vendor
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE django_react
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE django_react{%- endif %}
 
 {% endif -%}
-{%- endif -%}
-{%- if cookiecutter.sass_bootstrap == "enabled" -%}
-{%- if cookiecutter.feature_annotations == "on" -%}
-# START_FEATURE sass_bootstrap
-{%- endif %}
+
+
+{% if cookiecutter.sass_bootstrap == "enabled" -%}
+{%- if cookiecutter.feature_annotations == "on" -%}# START_FEATURE sass_bootstrap{%- endif %}
 RUN python manage.py compilescss
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE sass_bootstrap
+{% if cookiecutter.feature_annotations == "on" -%}# END_FEATURE sass_bootstrap{%- endif %}
 
 {% endif -%}
-{%- endif -%}
+
 RUN python manage.py collectstatic --noinput
 
 RUN rm /app/config/.env
@@ -69,7 +58,4 @@ RUN rm /app/config/.env
 EXPOSE 8000
 
 CMD ["gunicorn", "--bind", ":8000", "--workers", "3", "config.wsgi:application"]
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE docker
-{%- endif %}
-{%- endif %}
+{% if cookiecutter.feature_annotations == "on" %}# END_FEATURE docker{%- endif %}

--- a/{{cookiecutter.project_slug}}/common/models.py
+++ b/{{cookiecutter.project_slug}}/common/models.py
@@ -43,8 +43,6 @@ class User(AbstractUser, TimestampedModel):
     {%- endif %}
     {%- endif %}
 
-    def __str__(self):
-        return self.email
 {%- if cookiecutter.reference_examples == "on" %}
 {%- if cookiecutter.django_storages == "enabled" %}
 {%- if cookiecutter.feature_annotations == "on" %}

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -14,6 +14,7 @@ from django.contrib.messages import constants as messages
 
 import environ
 
+
 env = environ.Env(
     ALLOWED_HOSTS=(list, []),
     DEBUG=(bool, False),

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -1,15 +1,20 @@
 {
-  "name": "django-react-template",
+  "name": "sample-django-app",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "bootstrap": "^5.1.1",
+    {% if cookiecutter.sass_bootstrap == "enabled" -%}
+    "bootstrap": "^5.1.1"{% if cookiecutter.django_react == "enabled" %},{% endif %}
+    {%- endif %}
+    {% if cookiecutter.django_react == "enabled" -%}
     "django-react-loader": "^0.1.7",
     "nwb": "^0.24.7",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "webpack-bundle-tracker": "^0.4.3"
+    {%- endif %}
   },
+  {% if cookiecutter.django_react == "enabled" -%}
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
@@ -22,6 +27,7 @@
       "react-app/jest"
     ]
   },
+  {%- endif -%}
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
The current setup as written will have non-working elastic beanstalk deploy configuration (as tested by running cookiecutter with annotations turned off and most features turned on).

Primarily this was due to a formatting issue in the `predeploy.sh` hooks and missing node installation instructions in `django.config`.

This PR also modifies some formatting to be cleaner.