### PR TITLE
Add viewport and other required html meta

### DIFF
--- a/{{cookiecutter.project_slug}}/common/templates/base_templates/base.html
+++ b/{{cookiecutter.project_slug}}/common/templates/base_templates/base.html
@@ -11,8 +11,10 @@
 {%- endif %}
 
 {%- raw %}
-<html>
+<html lang="en">
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>{% endraw %}{{ cookiecutter.project_name }}{% raw %} - {% block title %}{% endblock %}</title>
 {%- endraw %}
 


### PR DESCRIPTION
The `viewport` meta is required for viewing mobile websites scaled correctly. The others are standard additions or "required" by spec.