### PR TITLE
adds in sample pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings

--- a/{{cookiecutter.project_slug}}/common/test/test_sample.py
+++ b/{{cookiecutter.project_slug}}/common/test/test_sample.py
@@ -1,0 +1,18 @@
+import pytest
+from django.urls import reverse, resolve
+
+from common import views
+
+
+class TestClass:
+
+    @pytest.mark.parametrize(
+        "url_name, url, view_class",
+        [
+            ("index", "/", views.IndexView),
+        ],
+    )
+    def test_urls(self, url_name, url, view_class):
+        resolver = resolve(url)
+        assert resolver.view_name == url_name
+        assert resolver.func.view_class == view_class

--- a/{{cookiecutter.project_slug}}/requirements.in
+++ b/{{cookiecutter.project_slug}}/requirements.in
@@ -3,6 +3,7 @@ django-environ
 django-extensions
 requests
 psycopg2
+pytest
 {%- if cookiecutter.feature_annotations == "on" %}
 
 ####### OPTIONAL FEATURES #######


### PR DESCRIPTION
There are still warnings present
```RemovedInDjango41Warning: 'django_extensions' defines default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'. Django now detects this configuration automatically. You can remove default_app_config.```
It seems to be that two packages that we use (`django_extensions` and `webpack_loader`) define `default_app_config`, which is not needed anymore. We might have to wait for a new version for them to remove it