### PR TITLE
Update Django to 4.2 and settings

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -405,6 +405,7 @@ else:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE django_storages
+{%- endif %}
 {%- else %}
 DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -204,7 +204,7 @@ MIDDLEWARE = [
     {%- if cookiecutter.feature_annotations == "on" %}
     # START_FEATURE user_action_tracking
     {%- endif %}
-    "common.middleware.UserActionTrackingMiddleware"
+    "common.middleware.UserActionTrackingMiddleware",
     {%- if cookiecutter.feature_annotations == "on" %}
     # END_FEATURE user_action_tracking
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -396,13 +396,18 @@ MESSAGE_TAGS = {
 {%- endif %}
 
 {%- if cookiecutter.django_storages == "enabled" %}
-{%- if cookiecutter.feature_annotations == "on" %}
+
+{% if cookiecutter.feature_annotations == "on" %}
 # START_FEATURE django_storages
 {%- endif %}
-if LOCALHOST:
+if LOCALHOST is True:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+    MEDIA_ROOT = ""
 else:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    AWS_DEFAULT_ACL = "private"
+    AWS_S3_FILE_OVERWRITE = False
+    AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME")
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE django_storages
 {%- endif %}
@@ -440,20 +445,6 @@ STATICFILES_FINDERS = [
     'sass_processor.finders.CssFinder',
 ]
 
-{%- if cookiecutter.django_storages == "enabled" %}
-{%- if cookiecutter.feature_annotations == "on" %}
-# START_FEATURE django_storages
-{%- endif %}
-if LOCALHOST is True:
-    MEDIA_ROOT = ""
-else:
-    AWS_DEFAULT_ACL = "private"
-    AWS_S3_FILE_OVERWRITE = False
-    AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME")
-{%- if cookiecutter.feature_annotations == "on" %}
-# END_FEATURE django_storages
-{%- endif %}
-{%- endif %}
 {%- if cookiecutter.debug_toolbar == "enabled" %}
 
 {% if cookiecutter.feature_annotations == "on" %}

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -401,10 +401,10 @@ MESSAGE_TAGS = {
 # START_FEATURE django_storages
 {%- endif %}
 if LOCALHOST is True:
-    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+    STORAGE_BACKEND_DEFAULT = "django.core.files.storage.FileSystemStorage"
     MEDIA_ROOT = ""
 else:
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    STORAGE_BACKEND_DEFAULT = "storages.backends.s3boto3.S3Boto3Storage"
     AWS_DEFAULT_ACL = "private"
     AWS_S3_FILE_OVERWRITE = False
     AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME")
@@ -412,11 +412,11 @@ else:
 # END_FEATURE django_storages
 {%- endif %}
 {%- else %}
-DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+STORAGE_BACKEND_DEFAULT = "django.core.files.storage.FileSystemStorage"
 {%- endif %}
 STORAGES = {
     "default": {
-        "BACKEND": DEFAULT_FILE_STORAGE,
+        "BACKEND": STORAGE_BACKEND_DEFAULT,
     },
     {%- if cookiecutter.sass_bootstrap == "enabled" %}
     {%- if cookiecutter.feature_annotations == "on" %}
@@ -435,7 +435,7 @@ STORAGES = {
     {%- endif %}
     {%- endif %}
     "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
     },
 }
 

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -394,16 +394,56 @@ MESSAGE_TAGS = {
 # END_FEATURE bootstrap_messages
 {%- endif %}
 {%- endif %}
+
+STORAGES = {
+    "default": {
+        {%- if cookiecutter.django_storages == "enabled" %}
+
+        {% if cookiecutter.feature_annotations == "on" %}
+        # START_FEATURE django_storages
+        {%- endif %}
+        "BACKEND": "django.core.files.storage.FileSystemStorage" if LOCALHOST is True else "storages.backends.s3boto3.S3Boto3Storage",
+        {%- if cookiecutter.feature_annotations == "on" %}
+        # END_FEATURE django_storages
+        {%- endif %}
+        {% else %}
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        {%- endif %}
+    },
+    {%- if cookiecutter.sass_bootstrap == "enabled" %}
+    {% if cookiecutter.feature_annotations == "on" %}
+    # START_FEATURE sass_bootstrap
+    {%- endif %}
+    "sass_processor": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "base_url": STATIC_URL,
+            "location": os.path.join(BASE_DIR, 'static'),
+        },
+        "ROOT": os.path.join(BASE_DIR, 'static'),
+    },
+    {%- if cookiecutter.feature_annotations == "on" %}
+    # END_FEATURE sass_bootstrap
+    {%- endif %}
+    {%- endif %}
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'sass_processor.finders.CssFinder',
+]
+
 {%- if cookiecutter.django_storages == "enabled" %}
 
 {% if cookiecutter.feature_annotations == "on" %}
 # START_FEATURE django_storages
 {%- endif %}
 if LOCALHOST is True:
-    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_ROOT = ""
 else:
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     AWS_DEFAULT_ACL = "private"
     AWS_S3_FILE_OVERWRITE = False
     AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME")
@@ -505,8 +545,7 @@ SASS_PROCESSOR_INCLUDE_DIRS = [
     os.path.join(BASE_DIR, 'static/styles'),
     os.path.join(BASE_DIR, 'node_modules'),
 ]
-SASS_PROCESSOR_ROOT = os.path.join(BASE_DIR, 'static')
-COMPRESS_ROOT = SASS_PROCESSOR_ROOT
+COMPRESS_ROOT = STORAGES["sass_processor"]["ROOT"]
 {%- if cookiecutter.feature_annotations == "on" %}
 # END_FEATURE sass_bootstrap
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings.py
+++ b/{{cookiecutter.project_slug}}/config/settings.py
@@ -395,23 +395,25 @@ MESSAGE_TAGS = {
 {%- endif %}
 {%- endif %}
 
+{%- if cookiecutter.django_storages == "enabled" %}
+{%- if cookiecutter.feature_annotations == "on" %}
+# START_FEATURE django_storages
+{%- endif %}
+if LOCALHOST:
+    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+else:
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+{%- if cookiecutter.feature_annotations == "on" %}
+# END_FEATURE django_storages
+{%- else %}
+DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+{%- endif %}
 STORAGES = {
     "default": {
-        {%- if cookiecutter.django_storages == "enabled" %}
-
-        {% if cookiecutter.feature_annotations == "on" %}
-        # START_FEATURE django_storages
-        {%- endif %}
-        "BACKEND": "django.core.files.storage.FileSystemStorage" if LOCALHOST is True else "storages.backends.s3boto3.S3Boto3Storage",
-        {%- if cookiecutter.feature_annotations == "on" %}
-        # END_FEATURE django_storages
-        {%- endif %}
-        {% else %}
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-        {%- endif %}
+        "BACKEND": DEFAULT_FILE_STORAGE,
     },
     {%- if cookiecutter.sass_bootstrap == "enabled" %}
-    {% if cookiecutter.feature_annotations == "on" %}
+    {%- if cookiecutter.feature_annotations == "on" %}
     # START_FEATURE sass_bootstrap
     {%- endif %}
     "sass_processor": {
@@ -430,6 +432,7 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
+
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -437,8 +440,7 @@ STATICFILES_FINDERS = [
 ]
 
 {%- if cookiecutter.django_storages == "enabled" %}
-
-{% if cookiecutter.feature_annotations == "on" %}
+{%- if cookiecutter.feature_annotations == "on" %}
 # START_FEATURE django_storages
 {%- endif %}
 if LOCALHOST is True:


### PR DESCRIPTION
@zags This is not yet tested, just putting this here so we have the full settings changes for `STORAGES` to be compatible with `django-storages` and `django-sass-processor`