### PR TITLE
Update health check config

### DIFF
--- a/{{cookiecutter.project_slug}}/.ebextensions/django.config
+++ b/{{cookiecutter.project_slug}}/.ebextensions/django.config
@@ -29,8 +29,8 @@ option_settings:
     WSGIPath: config.wsgi:application
   aws:elasticbeanstalk:environment:proxy:staticfiles:
     /static: staticfiles
-  aws:elasticbeanstalk:application:
-    Application Healthcheck URL: /health-check/
+  aws:elasticbeanstalk:environment:process:default:
+    HealthCheckPath: /health-check/
 
 files:
   "/home/ec2-user/.bashrc":


### PR DESCRIPTION
I believe the current health check config is not functional for new EB environments. This worked for the new Teachly environments.